### PR TITLE
Hotfix: Google Login Fix

### DIFF
--- a/src/main/java/com/nhnacademy/marketgg/auth/dto/response/GoogleProfile.java
+++ b/src/main/java/com/nhnacademy/marketgg/auth/dto/response/GoogleProfile.java
@@ -6,9 +6,13 @@ import lombok.ToString;
 @ToString
 public class GoogleProfile extends OauthResponse {
 
-    private final String email;
-    private final String name;
-    private final String provider;
+    private String email;
+    private String name;
+    private String provider;
+
+    public GoogleProfile() {
+        super(false, null);
+    }
 
     public GoogleProfile(String email, String name) {
         super(false, null);


### PR DESCRIPTION
## 개요
- 구글 로그인 오류가 발견되어 해결했습니다.

## 작업사항
- RestTemplate 에서 역 직렬화 과정에서 기본생성자 누락

